### PR TITLE
fix: exibir nomes de pessoas e empresas em UPPERCASE nos certificados

### DIFF
--- a/resources/views/certificados/certificado-interlab.blade.php
+++ b/resources/views/certificados/certificado-interlab.blade.php
@@ -84,7 +84,7 @@
 
             <p class="h3">Associação Rede de Metrologia e Ensaios do RS certifica que</p>
 
-            <p class="h4 font-weight-bold my-3">{{ $participante->laboratorio->nome }}</p>
+            <p class="h4 font-weight-bold my-3">{{ strtoupper($participante->laboratorio->nome) }}</p>
 
             <p class="h3">Participou do</p>
 

--- a/resources/views/certificados/certificado.blade.php
+++ b/resources/views/certificados/certificado.blade.php
@@ -122,7 +122,7 @@
 
             <p class="h3">Associação Rede de Metrologia e Ensaios do RS certifica que</p>
 
-            <p class="h4 font-weight-bold my-3">{{ $dadosDoc->content['participante_nome'] }}</p>
+            <p class="h4 font-weight-bold my-3">{{ strtoupper($dadosDoc->content['participante_nome']) }}</p>
 
             <p class="h3">Participou do curso de</p>
 
@@ -166,7 +166,7 @@
         <p class="field-value">{{ $dadosDoc->content['carga_horaria'] ?? '' }} horas</p>
 
         <p class="field-label">Instrutor(a):</p>
-        <p class="field-value">{{ $dadosDoc->content['instrutor_nome'] ?? '' }}</p>
+        <p class="field-value">{{ strtoupper($dadosDoc->content['instrutor_nome'] ?? '') }}</p>
 
         <p class="field-label">Local de Realização:</p>
         <p class="field-value">{{ $localRealizacaoCertificado ?? '' }}</p>

--- a/resources/views/certificados/tag-senha.blade.php
+++ b/resources/views/certificados/tag-senha.blade.php
@@ -183,12 +183,12 @@
 
     <div class="info-group">
         <span class="label">Empresa:</span>
-        <span class="value">{{ $dadosDoc->content['empresa_nome_razao'] }}</span>
+        <span class="value">{{ strtoupper($dadosDoc->content['empresa_nome_razao']) }}</span>
     </div>
 
     <div class="info-group">
         <span class="label">Laboratório:</span>
-        <span class="value">{{ $dadosDoc->content['laboratorio_nome'] }}</span>
+        <span class="value">{{ strtoupper($dadosDoc->content['laboratorio_nome']) }}</span>
     </div>
 
     <div class="info-group">


### PR DESCRIPTION
Aplica strtoupper() nos campos de nome de participante, instrutor, laboratório e empresa nos templates de certificado e carta-senha, garantindo apresentação em maiúsculas independente do dado armazenado.