### PR TITLE
fix: corrige formataMoeda para valores com milhar sem centavos

### DIFF
--- a/app/Helpers/String.php
+++ b/app/Helpers/String.php
@@ -84,7 +84,7 @@ function formataMoeda($valor): ?string
         }
 
         if (str_contains($valor, '.') && ! str_contains($valor, ',')) {
-            return $valor;
+            return substr_count($valor, '.') > 1 ? str_replace('.', '', $valor) : $valor;
         }
 
         if (str_contains($valor, ',') && ! str_contains($valor, '.')) {

--- a/tests/Feature/InscricaoInterlab/EditarInscritoInterlabTest.php
+++ b/tests/Feature/InscricaoInterlab/EditarInscritoInterlabTest.php
@@ -100,6 +100,25 @@ class EditarInscritoInterlabTest extends TestCase
         ]);
     }
 
+    public function test_salvar_aceita_valor_com_milhar_sem_centavos(): void
+    {
+        $inscrito = $this->criarInscritoCompleto([
+            'valor' => null,
+            'lancamento_financeiro_id' => null,
+        ]);
+
+        Livewire::test(EditarInscrito::class)
+            ->call('abrir', $inscrito->id)
+            ->call('carregarInscrito')
+            ->set('form.valor', '6.400.000')
+            ->call('salvar')
+            ->assertHasNoErrors();
+
+        $inscrito->refresh();
+
+        $this->assertSame(6400000.0, (float) $inscrito->valor);
+    }
+
     public function test_salvar_atualiza_lancamento_existente_sem_criar_novo(): void
     {
         $inscrito = $this->criarInscritoCompleto([


### PR DESCRIPTION
O campo "valor" na edição de inscritos usa máscara de dinheiro que pode gerar valores como "6.400.000" (milhar com múltiplos pontos e sem parte decimal). formataMoeda() assumia que qualquer "." sem "," já era um decimal válido e retornava o valor sem alteração, o que gerava erro 1366 (Incorrect decimal value) no MySQL ao salvar.