### PR TITLE
REWORK: Cadastro de Avaliador em um único passo

### DIFF
--- a/app/Http/Controllers/AvaliadorController.php
+++ b/app/Http/Controllers/AvaliadorController.php
@@ -53,16 +53,8 @@ class AvaliadorController extends Controller
             ->paginate(10)
             ->withQueryString();
 
-        $pessoas = Pessoa::select('uid', 'nome_razao', 'cpf_cnpj')
-            ->where('tipo_pessoa', 'PF')
-            ->whereNotIn('id', function ($query) {
-                $query->select('pessoa_id')->from('avaliadores');
-            })
-            ->get();
-
         return view('painel.avaliadores.index', [
             'avaliadores' => $avaliadores,
-            'pessoas' => $pessoas,
         ]);
     }
 
@@ -72,28 +64,66 @@ class AvaliadorController extends Controller
      **/
     public function create(Request $request): RedirectResponse
     {
+        $request->merge(return_only_nunbers($request->only('cpf_cnpj')));
+
+        $pessoa = Pessoa::where('uid', $request->pessoa_uid)->first();
+
         $request->validate(
             [
                 'pessoa_uid' => ['required', 'string', 'exists:pessoas,uid'],
+                'cpf_cnpj' => ['required', 'string', 'max:191', 'unique:pessoas,cpf_cnpj,'.$pessoa?->id], // TODO - adicionar validação de CPF/CNPJ
+                'curriculo' => ['file', 'mimes:doc,pdf,docx', 'max:5242880'], // 5mb
+                'data_ingresso' => ['nullable', Rule::date()->format('Y-m-d')],
+                'situacao' => ['required', 'string', Rule::in(['ATIVO', 'AVALIADOR', 'AVALIADOR EM TREINAMENTO', 'AVALIADOR LIDER', 'ESPECIALISTA', 'INATIVO'])],
             ],
             [
                 'pessoa_uid.required' => 'Dados inválidos, seleciona uma pessoa e envie novamente',
                 'pessoa_uid.string' => 'Dados inválidos, seleciona uma pessoa e envie novamente',
                 'pessoa_uid.exists' => 'Dados inválidos, seleciona uma pessoa e envie novamente',
+                'cpf_cnpj.required' => 'Preencha o campo CPF',
+                'cpf_cnpj.min' => 'CPF inválido',
+                'cpf_cnpj.max' => 'CPF inválido',
+                'curriculo.mimes' => 'Somente arquivos DOC, DOCX e PDF',
+                'curriculo.max' => 'Tamanho máximo 5MB',
+                'situacao.required' => 'Selecione uma situação.',
+                'situacao.in' => 'Selecione uma situação válida.',
             ]
         );
 
-        $pessoa = Pessoa::select('id')->where('uid', $request->pessoa_uid)->first();
-
-        // cria um avaliador vinculado a pessoa
+        // cria um avaliador vinculado a pessoa, já com os dados principais
         $avaliador = Avaliador::create([
             'pessoa_id' => $pessoa->id,
+            'exp_min_comprovada' => $request->get('exp_min_comprovada') ?? 0,
+            'curso_incerteza' => $request->get('curso_incerteza') ?? 0,
+            'curso_iso' => $request->get('curso_iso') ?? 0,
+            'curso_aud_interna' => $request->get('curso_aud_interna') ?? 0,
+            'parecer_psicologico' => $request->get('parecer_psicologico') ?? 0,
+            'data_ingresso' => $request->get('data_ingresso'),
+            'situacao' => $request->get('situacao'),
         ]);
 
         if (! $avaliador) {
             return redirect()->back()
                 ->with('avaliador-error', 'Ocorreu um erro! Revise os dados e tente novamente');
         }
+
+        // se foi enviado currículo
+        if ($request->hasFile('curriculo')) {
+            $fileName = sanitizeFileName(pathinfo($request->file('curriculo')->getClientOriginalName(), PATHINFO_FILENAME));
+            $extension = $request->file('curriculo')->getClientOriginalExtension();
+            $fileName = $fileName.'_'.time().'.'.$extension;
+            $request->file('curriculo')->move(public_path('curriculos'), $fileName);
+            $avaliador->update([
+                'curriculo' => 'curriculos/'.$fileName,
+            ]);
+        }
+
+        $pessoa->update([
+            'cpf_cnpj' => $request->get('cpf_cnpj'),
+            'rg_ie' => $request->get('rg_ie'),
+            'telefone' => $request->get('telefone'),
+            'email' => $request->get('email'),
+        ]);
 
         return redirect()->route('avaliador-insert', $avaliador->uid)
             ->with('success', 'Avaliador cadastrado com sucesso');
@@ -118,22 +148,36 @@ class AvaliadorController extends Controller
         // carrega areas de atuação do avaliador
         $areas_atuacao = AreaAtuacao::select('id', 'uid', 'descricao')->get();
 
-        // carrega endereço pessoal do avaliador
-        $endereco_pessoal = $avaliador->pessoa->enderecos()
-            ->where('pessoa_id', $avaliador->pessoa_id)
-            ->whereNull('avaliador_id')
-            ->first();
+        // carrega endereço pessoal e comercial do avaliador (avaliador novo ainda não tem pessoa vinculada)
+        $endereco_pessoal = null;
+        $endereco_comercial = null;
+        if ($avaliador->pessoa) {
+            $endereco_pessoal = $avaliador->pessoa->enderecos()
+                ->where('pessoa_id', $avaliador->pessoa_id)
+                ->whereNull('avaliador_id')
+                ->first();
 
-        // carrega endereço comercial do avaliador
-        $endereco_comercial = $avaliador->pessoa->enderecos()
-            ->where('avaliador_id', $avaliador->id)
-            ->first();
+            $endereco_comercial = $avaliador->pessoa->enderecos()
+                ->where('avaliador_id', $avaliador->id)
+                ->first();
+        }
 
         // carrega lista com empresas
         $empresas = Pessoa::select('id', 'uid', 'nome_razao', 'cpf_cnpj')
             ->where('tipo_pessoa', 'PJ')
             ->orderBy('nome_razao')
             ->get();
+
+        // avaliador novo: carrega pessoas físicas ainda não vinculadas a avaliadores, para o select da tela de inserção
+        $pessoas = collect();
+        if (! $avaliador->exists) {
+            $pessoas = Pessoa::select('uid', 'nome_razao', 'cpf_cnpj', 'rg_ie', 'telefone', 'email')
+                ->where('tipo_pessoa', 'PF')
+                ->whereNotIn('id', function ($query) {
+                    $query->select('pessoa_id')->from('avaliadores');
+                })
+                ->get();
+        }
 
         return view(
             'painel.avaliadores.edit',
@@ -146,6 +190,7 @@ class AvaliadorController extends Controller
                 'endereco_pessoal' => $endereco_pessoal,
                 'endereco_comercial' => $endereco_comercial,
                 'empresas' => $empresas,
+                'pessoas' => $pessoas,
             ]
         );
     }

--- a/database/migrations/2026_08_08_172627_create_avaliador_qualificacoes_table.php
+++ b/database/migrations/2026_08_08_172627_create_avaliador_qualificacoes_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('avaliador_qualificacoes', function (Blueprint $table) {
+            $table->id();
+            $table->string('uid')->unique();
+            $table->unsignedBigInteger('avaliador_id');
+            $table->string('ano')->nullable();
+            $table->string('atividade')->nullable();
+            $table->string('instrutor')->nullable();
+            $table->timestamps();
+
+            $table->foreign('avaliador_id')->references('id')->on('avaliadores')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('avaliador_qualificacoes');
+    }
+};

--- a/resources/js/custom.js
+++ b/resources/js/custom.js
@@ -281,6 +281,7 @@ window.onload = function(){
     '#tom-select-agenda-interlab-pessoa',
     '#tom-select-agendamento-curso-empresa-modal',
     '#tom-select-agendamento-curso-empresa-incompany',
+    '#tom-select-avaliador-pessoa',
   ]
   tomSelectBySelector.forEach((selector) => {
     const el = document.querySelector(selector)

--- a/resources/views/components/painel/avaliadores/dados-principais.blade.php
+++ b/resources/views/components/painel/avaliadores/dados-principais.blade.php
@@ -1,17 +1,53 @@
-<form method="POST" action="{{route('avaliador-update', $avaliador->uid)}}">
-  @csrf
-  <div class="row gy-3">
+<div class="row gy-3">
 
     <div class="col-8">
       <label class="form-label">Nome Completo<small class="text-danger-emphasis opacity-75"> *
         </small></label>
-      <input type="text" class="form-control" name="nome_razao"
-        value="{{ old('nome_razao') ?? ($avaliador->pessoa->nome_razao ?? null) }}" required>
-      @error('nome_razao')
-        <div class="text-warning">{{ $message }}</div>
-      @enderror
+      @if ($avaliador->uid)
+        <input type="text" class="form-control" name="nome_razao"
+          value="{{ old('nome_razao') ?? $avaliador->pessoa?->nome_razao }}" required>
+        @error('nome_razao')
+          <div class="text-warning">{{ $message }}</div>
+        @enderror
+      @else
+        <select id="tom-select-avaliador-pessoa" name="pessoa_uid" autocomplete="off" required>
+          <option value="">Digite para pesquisar</option>
+          @foreach ($pessoas as $pessoa)
+            <option value="{{ $pessoa->uid }}"
+              data-cpf="{{ $pessoa->cpf_cnpj }}"
+              data-rg="{{ $pessoa->rg_ie }}"
+              data-telefone="{{ $pessoa->telefone }}"
+              data-email="{{ $pessoa->email }}">
+              {{ $pessoa->cpf_cnpj }} | {{ $pessoa->nome_razao }}
+            </option>
+          @endforeach
+        </select>
+        @error('pessoa_uid')
+          <div class="text-warning">{{ $message }}</div>
+        @enderror
+        <p class="mt-2 mb-0">Caso a pessoa não esteja cadastrada ainda, <a href="{{ route('pessoa-insert') }}">Clique Aqui</a></p>
+
+        <script>
+          window.addEventListener('load', function () {
+            const pessoaSelect = document.getElementById('tom-select-avaliador-pessoa')
+
+            if (!pessoaSelect) {
+              return
+            }
+
+            pessoaSelect.addEventListener('change', function () {
+              const option = pessoaSelect.selectedOptions[0]
+
+              document.getElementById('input-cpf').value = option ? option.dataset.cpf : ''
+              document.getElementById('rg_ie').value = option ? option.dataset.rg : ''
+              document.getElementById('telefone').value = option ? option.dataset.telefone : ''
+              document.getElementById('email').value = option ? option.dataset.email : ''
+            })
+          })
+        </script>
+      @endif
     </div>
-    
+
     <div class="col-4">
       <label class="form-label">Situação<small class="text-danger-emphasis opacity-75"> *
         </small></label>
@@ -35,7 +71,7 @@
       <label class="form-label">CPF<small class="text-danger-emphasis opacity-75"> *
         </small></label>
       <input type="text" class="form-control" name="cpf_cnpj" id="input-cpf"
-        value="{{ old('cpf_cnpj') ?? ($avaliador->pessoa->cpf_cnpj ?? null) }}" required>
+        value="{{ old('cpf_cnpj') ?? $avaliador->pessoa?->cpf_cnpj }}" required>
       @error('cpf_cnpj')
         <div class="text-warning">{{ $message }}</div>
       @enderror
@@ -43,8 +79,8 @@
 
     <div class="col-4">
       <label class="form-label">RG</label>
-      <input type="number" class="form-control" name="rg_ie"
-        value="{{ old('rg_ie') ?? ($avaliador->pessoa->rg_ie ?? null) }}">
+      <input type="number" class="form-control" name="rg_ie" id="rg_ie"
+        value="{{ old('rg_ie') ?? $avaliador->pessoa?->rg_ie }}">
       @error('rg_ie')
         <div class="text-warning">{{ $message }}</div>
       @enderror
@@ -53,7 +89,7 @@
     <div class="col-4">
       <label class="form-label">Telefone</label>
       <input type="text" class="form-control" name="telefone" id="telefone"
-        value="{{ old('telefone') ?? ($avaliador->pessoa->telefone ?? null) }}">
+        value="{{ old('telefone') ?? $avaliador->pessoa?->telefone }}">
       @error('telefone')
         <div class="text-warning">{{ $message }}</div>
       @enderror
@@ -62,7 +98,7 @@
     <div class="col-4">
       <label class="form-label">Email</label>
       <input type="text" class="form-control" name="email" id="email"
-        value="{{ old('email') ?? ($avaliador->pessoa->email ?? null) }}">
+        value="{{ old('email') ?? $avaliador->pessoa?->email }}">
       @error('email')
         <div class="text-warning">{{ $message }}</div>
       @enderror
@@ -162,4 +198,3 @@
     </div>
 
   </div>
-</form>

--- a/resources/views/components/painel/avaliadores/edit.blade.php
+++ b/resources/views/components/painel/avaliadores/edit.blade.php
@@ -12,42 +12,44 @@
                              Dados Principais
                          </a>
                      </li>
-                     <li class="nav-item">
-                         <a class="nav-link" data-bs-toggle="tab" href="#enderecos" role="tab" aria-selected="true">
-                             Endereços
-                         </a>
-                     </li>
-                     <li class="nav-item">
-                         <a class="nav-link" data-bs-toggle="tab" href="#avaliacoes" role="tab"
-                             aria-selected="false">
-                             Avaliações
-                         </a>
-                     </li>
-                     <li class="nav-item">
-                         <a class="nav-link" data-bs-toggle="tab" href="#areasatuacao" role="tab"
-                             aria-selected="false">
-                             Áreas de atuação
-                         </a>
-                     </li>
-                     <li class="nav-item">
-                         <a class="nav-link" data-bs-toggle="tab" href="#qualificacoes" role="tab"
-                             aria-selected="false">
-                             Qualificações
-                         </a>
-                     </li>
-                     <li class="nav-item">
-                         <a class="nav-link" data-bs-toggle="tab" href="#controlestatus" role="tab"
-                             aria-selected="false">
-                             Status
-                         </a>
-                     </li>
+                     @if ($avaliador->uid)
+                         <li class="nav-item">
+                             <a class="nav-link" data-bs-toggle="tab" href="#enderecos" role="tab" aria-selected="true">
+                                 Endereços
+                             </a>
+                         </li>
+                         <li class="nav-item">
+                             <a class="nav-link" data-bs-toggle="tab" href="#avaliacoes" role="tab"
+                                 aria-selected="false">
+                                 Avaliações
+                             </a>
+                         </li>
+                         <li class="nav-item">
+                             <a class="nav-link" data-bs-toggle="tab" href="#areasatuacao" role="tab"
+                                 aria-selected="false">
+                                 Áreas de atuação
+                             </a>
+                         </li>
+                         <li class="nav-item">
+                             <a class="nav-link" data-bs-toggle="tab" href="#qualificacoes" role="tab"
+                                 aria-selected="false">
+                                 Qualificações
+                             </a>
+                         </li>
+                         <li class="nav-item">
+                             <a class="nav-link" data-bs-toggle="tab" href="#controlestatus" role="tab"
+                                 aria-selected="false">
+                                 Status
+                             </a>
+                         </li>
+                     @endif
                  </ul>
 
                  <div class="tab-content">
                      <div class="tab-pane active" id="principal" role="tabpanel"> <!-- Dados principais -->
                          <div class="row">
                              <div class="col-12">
-                                 <x-painel.avaliadores.dados-principais :avaliador="$avaliador" />
+                                 <x-painel.avaliadores.dados-principais :avaliador="$avaliador" :pessoas="$pessoas" />
                              </div>
 
                              @if ($avaliador->uid)
@@ -65,25 +67,28 @@
                              @endif
                          </div>
                      </div>
-                     <div class="tab-pane" id="enderecos" role="tabpanel">
-                         <x-painel.avaliadores.enderecos :enderecopessoal="$enderecopessoal" :enderecocomercial="$enderecocomercial" :avaliador="$avaliador" />
-                     </div>
 
-                     <div class="tab-pane" id="avaliacoes" role="tabpanel">
-                         <x-painel.avaliadores.avaliacoes :avaliacoes="$avaliacoes" :avaliador="$avaliador" :empresas="$empresas" />
-                     </div>
+                     @if ($avaliador->uid)
+                         <div class="tab-pane" id="enderecos" role="tabpanel">
+                             <x-painel.avaliadores.enderecos :enderecopessoal="$enderecopessoal" :enderecocomercial="$enderecocomercial" :avaliador="$avaliador" />
+                         </div>
 
-                     <div class="tab-pane" id="areasatuacao" role="tabpanel">
-                         <x-painel.avaliadores.areas-atuacao :areasatuacao="$areasatuacao" :avaliador="$avaliador" />
-                     </div>
+                         <div class="tab-pane" id="avaliacoes" role="tabpanel">
+                             <x-painel.avaliadores.avaliacoes :avaliacoes="$avaliacoes" :avaliador="$avaliador" :empresas="$empresas" />
+                         </div>
 
-                     <div class="tab-pane" id="qualificacoes" role="tabpanel">
-                         <x-painel.avaliadores.qualificacoes :qualificacoes="$qualificacoes" :qualificacoeslist="$qualificacoeslist" :avaliador="$avaliador" />
-                     </div>
+                         <div class="tab-pane" id="areasatuacao" role="tabpanel">
+                             <x-painel.avaliadores.areas-atuacao :areasatuacao="$areasatuacao" :avaliador="$avaliador" />
+                         </div>
 
-                     <div class="tab-pane" id="controlestatus" role="tabpanel">
-                         <x-painel.avaliadores.status :avaliador="$avaliador" />
-                     </div>
+                         <div class="tab-pane" id="qualificacoes" role="tabpanel">
+                             <x-painel.avaliadores.qualificacoes :qualificacoes="$qualificacoes" :qualificacoeslist="$qualificacoeslist" :avaliador="$avaliador" />
+                         </div>
+
+                         <div class="tab-pane" id="controlestatus" role="tabpanel">
+                             <x-painel.avaliadores.status :avaliador="$avaliador" />
+                         </div>
+                     @endif
 
                  </div>
 

--- a/resources/views/components/painel/avaliadores/list.blade.php
+++ b/resources/views/components/painel/avaliadores/list.blade.php
@@ -10,35 +10,9 @@
       <div class="col-12">
         
         <div class="hstack gap-2 flex-wrap mb-3 justify-content-end">
-            <button class="btn btn-sm btn-success" type="button" data-bs-toggle="collapse" data-bs-target="#collapseExample" aria-expanded="false" aria-controls="collapseExample">
+            <a class="btn btn-sm btn-success" href="{{ route('avaliador-insert') }}">
               <i class="ri-add-line align-bottom me-1"></i> Adicionar Avaliador
-            </button>
-          </div>
-
-          <div class="collapse" id="collapseExample">
-            <div class="card mb-3 shadow-none">
-                <div class="card-body">
-                  <form action="{{route('avaliador-create')}}" method="POST">
-                    @csrf
-                    <div class="row">
-                      <div class="col-10">
-                        <select id="tom-select" name="pessoa_uid" autocomplete="off">
-                          <option value="">Digite para pesquisar</option>
-                          @foreach($pessoas as $pessoa)
-                            <option value="{{ $pessoa->uid }}">{{ $pessoa->cpf_cnpj }} | {{ $pessoa->nome_razao }}</option>
-                          @endforeach
-                        </select>
-                        @error('pessoa_uid')<div class="text-warning">{{ $message }}</div>@enderror
-                      </div>
-                      <div class="col-2">
-                        <button class="btn btn-success" type="submit">Adicionar</button>
-                      </div>
-                    </div>
-                  </form>
-                  <p>Caso a pessoa não esteja cadastrada ainda, <a href="{{ route('pessoa-insert') }}">Clique Aqui</a></p>
-                  
-                </div>
-            </div>
+            </a>
           </div>
         </div>
       </div>

--- a/resources/views/painel/avaliadores/edit.blade.php
+++ b/resources/views/painel/avaliadores/edit.blade.php
@@ -23,6 +23,7 @@
         :enderecopessoal="$endereco_pessoal"
         :enderecocomercial="$endereco_comercial"
         :empresas="$empresas"
+        :pessoas="$pessoas"
       />
     </div>
 

--- a/resources/views/painel/avaliadores/index.blade.php
+++ b/resources/views/painel/avaliadores/index.blade.php
@@ -8,7 +8,7 @@
 
 <div class="row">
   <div class="col">
-    <x-painel.avaliadores.list :avaliadores="$avaliadores" :pessoas="$pessoas"/>
+    <x-painel.avaliadores.list :avaliadores="$avaliadores"/>
   </div>
 </div>
 

--- a/tests/Feature/AvaliadorCadastroTest.php
+++ b/tests/Feature/AvaliadorCadastroTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Avaliador;
+use App\Models\Permission;
+use App\Models\User;
+use Database\Factories\PessoaFactory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AvaliadorCadastroTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function usuarioFuncionario(): User
+    {
+        $user = User::factory()->create();
+
+        $permission = Permission::withoutEvents(function (): Permission {
+            return Permission::query()->firstOrCreate(['permission' => 'funcionario']);
+        });
+
+        $user->permissions()->syncWithoutDetaching([$permission->id]);
+
+        return $user;
+    }
+
+    public function test_listagem_nao_exibe_mais_busca_de_pessoas(): void
+    {
+        $response = $this->actingAs($this->usuarioFuncionario())->get(route('avaliador-index'));
+
+        $response->assertOk();
+        $response->assertSee(route('avaliador-insert'), false);
+        $response->assertDontSee('id="tom-select"', false);
+        $response->assertDontSee('Caso a pessoa não esteja cadastrada ainda', false);
+    }
+
+    public function test_tela_de_insercao_sem_uid_exibe_apenas_aba_dados_principais(): void
+    {
+        $pessoa = PessoaFactory::new()->create(['tipo_pessoa' => 'PF']);
+
+        $response = $this->actingAs($this->usuarioFuncionario())->get(route('avaliador-insert'));
+
+        $response->assertOk();
+        $response->assertSee('id="tom-select-avaliador-pessoa"', false);
+        $response->assertSee($pessoa->uid, false);
+        $response->assertDontSee('id="enderecos"', false);
+        $response->assertDontSee('id="avaliacoes"', false);
+        $response->assertDontSee('id="areasatuacao"', false);
+        $response->assertDontSee('id="qualificacoes"', false);
+        $response->assertDontSee('id="controlestatus"', false);
+    }
+
+    public function test_tela_de_insercao_nao_lista_pessoa_ja_vinculada_a_avaliador(): void
+    {
+        $pessoaLivre = PessoaFactory::new()->create(['tipo_pessoa' => 'PF']);
+        $pessoaVinculada = PessoaFactory::new()->create(['tipo_pessoa' => 'PF']);
+        Avaliador::create(['pessoa_id' => $pessoaVinculada->id]);
+
+        $response = $this->actingAs($this->usuarioFuncionario())->get(route('avaliador-insert'));
+
+        $response->assertSee($pessoaLivre->uid, false);
+        $response->assertDontSee($pessoaVinculada->uid, false);
+    }
+
+    public function test_create_cadastra_avaliador_em_um_unico_submit_e_atualiza_pessoa(): void
+    {
+        $pessoa = PessoaFactory::new()->create([
+            'tipo_pessoa' => 'PF',
+            'cpf_cnpj' => '11122233344',
+            'rg_ie' => '111111',
+            'telefone' => '11999998888',
+            'email' => 'antigo@example.com',
+        ]);
+
+        $this->assertDatabaseCount('avaliadores', 0);
+
+        $response = $this->actingAs($this->usuarioFuncionario())->post(route('avaliador-create'), [
+            'pessoa_uid' => $pessoa->uid,
+            'situacao' => 'ATIVO',
+            'cpf_cnpj' => '999.888.777-66',
+            'rg_ie' => '222222',
+            'telefone' => '11988887777',
+            'email' => 'novo@example.com',
+            'data_ingresso' => '2026-01-01',
+            'exp_min_comprovada' => '1',
+        ]);
+
+        $avaliador = Avaliador::where('pessoa_id', $pessoa->id)->first();
+
+        $this->assertNotNull($avaliador);
+        $response->assertRedirect(route('avaliador-insert', $avaliador->uid));
+        $response->assertSessionHas('success');
+        $this->assertEquals('ATIVO', $avaliador->situacao);
+        $this->assertEquals('2026-01-01', $avaliador->data_ingresso->format('Y-m-d'));
+        $this->assertTrue((bool) $avaliador->exp_min_comprovada);
+
+        $pessoa->refresh();
+        $this->assertEquals('99988877766', $pessoa->getRawOriginal('cpf_cnpj'));
+        $this->assertEquals('222222', $pessoa->rg_ie);
+        $this->assertEquals('11988887777', $pessoa->getRawOriginal('telefone'));
+        $this->assertEquals('novo@example.com', $pessoa->email);
+    }
+
+    public function test_create_exige_pessoa_e_situacao(): void
+    {
+        $response = $this->actingAs($this->usuarioFuncionario())->post(route('avaliador-create'), []);
+
+        $response->assertSessionHasErrors(['pessoa_uid', 'cpf_cnpj', 'situacao']);
+        $this->assertDatabaseCount('avaliadores', 0);
+    }
+
+    public function test_edicao_de_avaliador_existente_continua_exibindo_todas_as_abas(): void
+    {
+        $pessoa = PessoaFactory::new()->create(['tipo_pessoa' => 'PF']);
+        $avaliador = Avaliador::create(['pessoa_id' => $pessoa->id]);
+
+        $response = $this->actingAs($this->usuarioFuncionario())->get(route('avaliador-insert', $avaliador->uid));
+
+        $response->assertOk();
+        $response->assertSee('id="enderecos"', false);
+        $response->assertDontSee('id="tom-select-avaliador-pessoa"', false);
+    }
+}


### PR DESCRIPTION
## Resumo
- "Adicionar Avaliador" na listagem agora é um link direto para a tela de inserção (sem UID), sem passo intermediário de criar um avaliador vazio.
- Na tela de inserção sem UID, só a aba "Dados Principais" aparece; "Nome Completo" vira um Tom Select que lista pessoas físicas ainda não vinculadas a avaliadores, preenchendo CPF/RG/Telefone/Email automaticamente (editáveis).
- O botão "Salvar" cria o avaliador em um único submit (dados principais + vínculo com a pessoa); redireciona para a tela com o UID, revelando as demais abas.
- Fluxo de edição de avaliadores existentes permanece inalterado.
- Busca de pessoas removida da listagem.
- Incluída migration para `avaliador_qualificacoes` (tabela usada pelo model `Qualificacao` e pelo controller, mas sem migration versionada no repo — bloqueava qualquer teste de feature na tela de avaliador).

## Test plan
- [x] `tests/Feature/AvaliadorCadastroTest.php` (6 testes): listagem sem busca, tela de inserção só com aba principal, filtro de pessoas já vinculadas, criação em único submit com atualização da pessoa, validação obrigatória, edição existente com todas as abas.
- [x] Suíte completa (`php artisan test --compact`): 146 passando, 9 falhas pré-existentes e não relacionadas (confirmado isolando via stash).
- [x] `vendor/bin/pint --dirty` limpo.
- [x] `npm run build` ok, novo `#tom-select-avaliador-pessoa` presente no bundle e registrado em `custom.js`.
- [x] Teste end-to-end com navegador real (Playwright): login, busca com autocomplete funcionando, autopreenchimento de CPF/RG/Telefone/Email, submit único, redirect com UID, abas reveladas, sem erros de console.
- [x] Teste manual guiado pelo autor da tarefa.
