### PR TITLE
FEAT/COBRANCAS-AVALIACOES-310: gera cobranca ao marcar Carta Reconhecimento = SIM

### DIFF
--- a/app/Actions/Financeiro/GerarLancamentoAvaliacaoAction.php
+++ b/app/Actions/Financeiro/GerarLancamentoAvaliacaoAction.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Actions\Financeiro;
+
+use App\Mail\LancamentoAvaliacaoNotification;
+use App\Models\AgendaAvaliacao;
+use App\Models\CentroCusto;
+use App\Models\LancamentoFinanceiro;
+use App\Models\PlanoConta;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Mail;
+
+class GerarLancamentoAvaliacaoAction
+{
+    /**
+     * Gera o lançamento financeiro de uma avaliação (imutável: se já existir, apenas o retorna).
+     */
+    public function execute(AgendaAvaliacao $avaliacao): LancamentoFinanceiro
+    {
+        $lancamento = LancamentoFinanceiro::where('agenda_avaliacao_id', $avaliacao->id)->first();
+
+        if ($lancamento) {
+            return $lancamento;
+        }
+
+        $avaliacao->loadMissing('laboratorio.pessoa');
+
+        $lancamento = LancamentoFinanceiro::create([
+            'pessoa_id' => $avaliacao->laboratorio->pessoa->id,
+            'agenda_avaliacao_id' => $avaliacao->id,
+            'historico' => 'Avaliação - '.$avaliacao->laboratorio->nome_laboratorio.' - '.Carbon::parse($avaliacao->data_inicio)->format('d/m/Y'),
+            'valor' => $avaliacao->valor_proposta,
+            'centro_custo_id' => CentroCusto::ID_AVALIACAO,
+            'plano_conta_id' => PlanoConta::ID_RECEITA_PRESTACAO_SERVICOS,
+            'tipo_lancamento' => 'CREDITO',
+            'data_emissao' => now(),
+            'status' => 'PROVISIONADO',
+        ]);
+
+        Mail::to('financeiro@redemetrologica.com.br')->send(new LancamentoAvaliacaoNotification($avaliacao, $lancamento));
+
+        return $lancamento;
+    }
+}

--- a/app/Http/Controllers/AgendaAvaliacaoController.php
+++ b/app/Http/Controllers/AgendaAvaliacaoController.php
@@ -2,11 +2,13 @@
 
 namespace App\Http\Controllers;
 
+use App\Actions\Financeiro\GerarLancamentoAvaliacaoAction;
 use App\Models\AgendaAvaliacao;
 use App\Models\AreaAvaliada;
 use App\Models\AvaliacaoAvaliador;
 use App\Models\Avaliador;
 use App\Models\Laboratorio;
+use App\Models\LancamentoFinanceiro;
 use App\Models\TipoAvaliacao;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
@@ -179,10 +181,26 @@ class AgendaAvaliacaoController extends Controller
         $validate['validade_certificado'] = $request->validade_certificado
             ?? Carbon::parse($request->data_fim)->addYears(1)->addMonths(3)->format('Y-m-d');
 
+        $blockMessage = null;
+        $lancamentoExistente = LancamentoFinanceiro::where('agenda_avaliacao_id', $avaliacao->id)->exists();
+        $cartaSolicitada = $request->input('carta_reconhecimento');
+
+        if ($cartaSolicitada !== null) {
+            if ((int) $cartaSolicitada === 1 && (empty($avaliacao->valor_proposta) || (float) $avaliacao->valor_proposta <= 0)) {
+                unset($validate['carta_reconhecimento']);
+                $blockMessage = 'Defina um valor de proposta válido antes de marcar a Carta de Reconhecimento como SIM.';
+            }
+
+            if ((int) $cartaSolicitada === 0 && (int) $avaliacao->carta_reconhecimento === 1 && $lancamentoExistente) {
+                unset($validate['carta_reconhecimento']);
+                $blockMessage = 'Já há um lançamento financeiro para essa avaliação. Esse status só pode ser trocado se o lançamento for excluido.';
+            }
+        }
+
         $avaliacao->update($validate);
 
-        // SE CARTA RECONHECIMENTO = SIM adiciona AvaliacaoAvaliador para cada avaliador
-        if ($request->carta_reconhecimento == 1) {
+        // SE CARTA RECONHECIMENTO = SIM adiciona AvaliacaoAvaliador para cada avaliador e gera a cobrança
+        if ((int) $avaliacao->carta_reconhecimento === 1) {
 
             $avaliacao_avaliadores = AreaAvaliada::where('avaliacao_id', $avaliacao->id)->get();
 
@@ -200,6 +218,12 @@ class AgendaAvaliacaoController extends Controller
                 );
             }
 
+            app(GerarLancamentoAvaliacaoAction::class)->execute($avaliacao);
+
+        }
+
+        if ($blockMessage) {
+            return redirect()->back()->with('error', $blockMessage);
         }
 
         return redirect()->back()->with('success', 'Dados atualizados com sucesso');

--- a/app/Mail/LancamentoAvaliacaoNotification.php
+++ b/app/Mail/LancamentoAvaliacaoNotification.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\AgendaAvaliacao;
+use App\Models\LancamentoFinanceiro;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Carbon;
+
+class LancamentoAvaliacaoNotification extends Mailable implements ShouldQueue
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * The number of times the job may be attempted.
+     */
+    public $tries = 3;
+
+    /**
+     * The maximum number of seconds the job can run.
+     */
+    public $timeout = 120;
+
+    public array $dados_email = [];
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct(AgendaAvaliacao $avaliacao, LancamentoFinanceiro $lancamento)
+    {
+        $avaliacao->loadMissing('laboratorio');
+
+        $this->dados_email = [
+            'laboratorio_nome' => $avaliacao->laboratorio->nome_laboratorio,
+            'data_inicio' => Carbon::parse($avaliacao->data_inicio)->format('d/m/Y'),
+            'valor' => formataValorBr($lancamento->valor),
+            'historico' => $lancamento->historico,
+            'link_lancamento' => route('lancamento-financeiro-insert', $lancamento->uid),
+        ];
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Novo lançamento financeiro - '.$this->dados_email['laboratorio_nome'],
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.lancamento-avaliacao',
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/app/Models/CentroCusto.php
+++ b/app/Models/CentroCusto.php
@@ -27,6 +27,9 @@ class CentroCusto extends Model
     /** ID do centro de custo INTERLABORATORIAL (inscrições em interlab). */
     public const ID_INTERLABORATORIAL = 4;
 
+    /** ID do centro de custo AVALIAÇÃO (cobrança de avaliações). */
+    public const ID_AVALIACAO = 5;
+
     public function getActivitylogOptions(): LogOptions
     {
         return LogOptions::defaults()

--- a/resources/views/emails/lancamento-avaliacao.blade.php
+++ b/resources/views/emails/lancamento-avaliacao.blade.php
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+  <meta charset="UTF-8">
+</head>
+<body style="background-color: #D4DADE; color: #5a6576; font: 14px/1.4 Helvetica, Arial, sans-serif; margin: 0; padding: 0;">
+  <div style="max-width: 600px; margin: 0 auto; padding: 20px;">
+    <div style="margin-top: 1.8rem; margin-bottom: 1.8rem;">
+      <figure style="text-align: center;">
+        <img src="{{ asset('build\images\site\LOGO_REDE_COLOR.png') }}" alt="Rede Metrológica RS" width="140px" style="max-width: 50%">
+      </figure>
+    </div>
+
+    <div style="background-color: #fff; padding: 20px; border-radius: 3px; box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);">
+      <h3>Novo lançamento financeiro - Avaliação</h3>
+      <p>
+        Foi gerado um lançamento financeiro para a avaliação abaixo.
+      </p>
+      <p>
+        Laboratório: {{ $dados_email['laboratorio_nome'] }} <br>
+        Data início: {{ $dados_email['data_inicio'] }} <br>
+        Valor: R$ {{ $dados_email['valor'] }} <br>
+        Histórico: {{ $dados_email['historico'] }} <br>
+      </p>
+      <p>
+        <a href="{{ $dados_email['link_lancamento'] }}">Ver lançamento no painel</a>
+      </p>
+      <br>
+      <p>
+        Atenciosamente,<br>
+        Equipe Rede Metrológica RS
+      </p>
+    </div>
+    <div style="text-align: center;"><span style="font-size: 12px;">© 2025 Sistema Rede Metrológica RS.</sp></div>
+  </div>
+</body>
+</html>

--- a/tests/Feature/Avaliacoes/GerarCobrancaAvaliacaoTest.php
+++ b/tests/Feature/Avaliacoes/GerarCobrancaAvaliacaoTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Tests\Feature\Avaliacoes;
+
+use App\Actions\Financeiro\GerarLancamentoAvaliacaoAction;
+use App\Mail\LancamentoAvaliacaoNotification;
+use App\Models\AgendaAvaliacao;
+use App\Models\CentroCusto;
+use App\Models\Laboratorio;
+use App\Models\LancamentoFinanceiro;
+use App\Models\Pessoa;
+use App\Models\PlanoConta;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class GerarCobrancaAvaliacaoTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createFuncionarioUser(): User
+    {
+        $user = User::query()->create([
+            'name' => 'Funcionário Teste',
+            'email' => 'func-'.Str::random(8).'@example.com',
+            'password' => bcrypt('password'),
+            'temporary_password' => false,
+        ]);
+
+        $permissionId = DB::table('permissions')->where('permission', 'funcionario')->value('id');
+        if ($permissionId === null) {
+            $permissionId = DB::table('permissions')->insertGetId([
+                'permission' => 'funcionario',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+
+        DB::table('permission_user')->insert([
+            'permission_id' => $permissionId,
+            'user_id' => $user->id,
+        ]);
+
+        return $user->fresh();
+    }
+
+    private function createAvaliacao(array $atributos = []): AgendaAvaliacao
+    {
+        $pessoa = Pessoa::query()->create([
+            'nome_razao' => 'Laboratorio Teste Ltda',
+            'cpf_cnpj' => str_pad((string) random_int(10000000000000, 99999999999999), 14, '0', STR_PAD_LEFT),
+            'tipo_pessoa' => 'PJ',
+        ]);
+
+        $laboratorio = Laboratorio::query()->create([
+            'pessoa_id' => $pessoa->id,
+            'nome_laboratorio' => 'Laboratorio Teste',
+        ]);
+
+        return AgendaAvaliacao::query()->create(array_merge([
+            'laboratorio_id' => $laboratorio->id,
+            'data_inicio' => now()->toDateString(),
+            'valor_proposta' => 1500,
+            'carta_reconhecimento' => 0,
+        ], $atributos));
+    }
+
+    public function test_carta_sim_com_valor_proposta_cria_lancamento_e_notifica_financeiro(): void
+    {
+        Mail::fake();
+
+        $avaliacao = $this->createAvaliacao();
+        $user = $this->createFuncionarioUser();
+
+        $response = $this->actingAs($user)->post(route('avaliacao-update', $avaliacao->uid), [
+            'carta_reconhecimento' => '1',
+        ]);
+
+        $response->assertSessionHas('success');
+
+        $avaliacao->refresh();
+        $this->assertEquals(1, $avaliacao->carta_reconhecimento);
+
+        $this->assertDatabaseCount('lancamentos_financeiros', 1);
+        $this->assertDatabaseHas('lancamentos_financeiros', [
+            'agenda_avaliacao_id' => $avaliacao->id,
+            'pessoa_id' => $avaliacao->laboratorio->pessoa_id,
+            'tipo_lancamento' => 'CREDITO',
+            'status' => 'PROVISIONADO',
+            'centro_custo_id' => CentroCusto::ID_AVALIACAO,
+            'plano_conta_id' => PlanoConta::ID_RECEITA_PRESTACAO_SERVICOS,
+            'valor' => 1500,
+        ]);
+
+        Mail::assertQueued(LancamentoAvaliacaoNotification::class, function ($mail) {
+            return $mail->hasTo('financeiro@redemetrologica.com.br');
+        });
+    }
+
+    public function test_carta_sim_sem_valor_proposta_nao_altera_status_nem_cria_lancamento(): void
+    {
+        Mail::fake();
+
+        $avaliacao = $this->createAvaliacao(['valor_proposta' => null]);
+        $user = $this->createFuncionarioUser();
+
+        $response = $this->actingAs($user)->post(route('avaliacao-update', $avaliacao->uid), [
+            'carta_reconhecimento' => '1',
+        ]);
+
+        $response->assertSessionHas('error');
+
+        $avaliacao->refresh();
+        $this->assertEquals(0, $avaliacao->carta_reconhecimento);
+        $this->assertDatabaseCount('lancamentos_financeiros', 0);
+        Mail::assertNothingQueued();
+    }
+
+    public function test_resalvar_carta_sim_com_lancamento_existente_nao_cria_nem_altera(): void
+    {
+        Mail::fake();
+
+        $avaliacao = $this->createAvaliacao(['carta_reconhecimento' => 1]);
+        app(GerarLancamentoAvaliacaoAction::class)->execute($avaliacao);
+        $lancamentoOriginal = LancamentoFinanceiro::where('agenda_avaliacao_id', $avaliacao->id)->firstOrFail();
+
+        $user = $this->createFuncionarioUser();
+
+        $response = $this->actingAs($user)->post(route('avaliacao-update', $avaliacao->uid), [
+            'carta_reconhecimento' => '1',
+        ]);
+
+        $response->assertSessionHas('success');
+        $this->assertDatabaseCount('lancamentos_financeiros', 1);
+        $this->assertEquals($lancamentoOriginal->valor, LancamentoFinanceiro::find($lancamentoOriginal->id)->valor);
+        Mail::assertQueued(LancamentoAvaliacaoNotification::class, 1);
+    }
+
+    public function test_carta_nao_com_lancamento_existente_bloqueia_alteracao(): void
+    {
+        Mail::fake();
+
+        $avaliacao = $this->createAvaliacao(['carta_reconhecimento' => 1]);
+        app(GerarLancamentoAvaliacaoAction::class)->execute($avaliacao);
+
+        $user = $this->createFuncionarioUser();
+
+        $response = $this->actingAs($user)->post(route('avaliacao-update', $avaliacao->uid), [
+            'carta_reconhecimento' => '0',
+        ]);
+
+        $response->assertSessionHas('error', 'Já há um lançamento financeiro para essa avaliação. Esse status só pode ser trocado se o lançamento for excluido.');
+
+        $avaliacao->refresh();
+        $this->assertEquals(1, $avaliacao->carta_reconhecimento);
+        $this->assertDatabaseCount('lancamentos_financeiros', 1);
+    }
+}


### PR DESCRIPTION
## Resumo
- Ao confirmar Carta Reconhecimento = SIM na tela de Avaliação, cria (uma única vez) um `LancamentoFinanceiro` CREDITO/PROVISIONADO vinculado à avaliação, seguindo o mesmo padrão de curso/interlab (centro de custo AVALIAÇÃO, plano de contas Receita Prestação de Serviços).
- Notifica `financeiro@redemetrologica.com.br` por e-mail (fila) somente na criação do lançamento; falha no e-mail não desfaz o lançamento.
- Bloqueia mudar para SIM quando `valor_proposta` está vazio/0, e bloqueia mudar para NÃO quando já existe lançamento — em ambos os casos exibe mensagem de erro e não altera o campo.
- Mantém o fluxo existente: dialog de confirmação do frontend e criação/atualização de `AvaliacaoAvaliador`.

## Testes
- 4 testes novos em `tests/Feature/Avaliacoes/GerarCobrancaAvaliacaoTest.php`: criação, pré-condição de valor, imutabilidade no re-save, bloqueio do NÃO.
- Suite `tests/Feature/Avaliacoes` (10 testes) passando via `vendor/bin/pest`.
- Validado manualmente end-to-end (login real, HTTP, MySQL, e-mail) via Docker/Sail: os 4 cenários de aceite confirmados, incluindo a criação do `AvaliacaoAvaliador`.

## Fora de escopo (decisão registrada)
- Bug pré-existente em `LancamentoFinanceiro::avaliacao()` (usa `AgendaInterlab::class` em vez de `AgendaAvaliacao::class`) não foi corrigido — fica para task futura.
- Envio da pesquisa de satisfação (task futura).

## Test plan
- [x] Carta=SIM + valor>0 + sem lançamento → cria 1 lançamento CREDITO/PROVISIONADO
- [x] Carta=SIM + valor vazio/0 → não altera o status
- [x] Re-salvar com Carta=SIM e lançamento existente → não cria nem altera
- [x] Carta=NÃO com lançamento existente → bloqueia e status não muda
- [x] E-mail enfileirado para financeiro@redemetrologica.com.br na criação
- [x] AvaliacaoAvaliador continua sendo criado/atualizado